### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,6 +1,8 @@
 name: Lint
 run-name: ${{ github.actor }} is testing out GitHub Actions 🚀
 on: [ push ]
+permissions:
+  contents: read
 jobs:
   Explore-GitHub-Actions:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Artboomy/netlogs/security/code-scanning/1](https://github.com/Artboomy/netlogs/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. Since the workflow only checks out code, installs dependencies, and runs ESLint, it does not require any write permissions. The minimal required permission is `contents: read`, which allows the workflow to read the repository contents. This change ensures the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
